### PR TITLE
Adding support for CRON tasks

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -5,17 +5,21 @@ ADD php.ini /usr/local/etc/php/php.ini
 ADD ext-apcu.ini /usr/local/etc/php/conf.d/ext-acpu.ini
 
 # installs missing php dependencies
-RUN pecl install apcu-5.1.5 \
-    && pecl install xdebug-2.4.0
+RUN pecl install apcu \
+    && pecl install xdebug
 
 RUN apt-get update \
-    && apt-get install -y zlib1g-dev # dependency for php zip extension
+    && apt-get install -y cron zlib1g-dev # dependency for php zip extension
 
 RUN docker-php-ext-install pdo_mysql \
     && docker-php-ext-install zip
 
 # enables Apache's rewrite module
 RUN a2enmod rewrite
+
+# register cron
+ADD crontab /tmp/
+RUN crontab /tmp/crontab
 
 # installs composer
 RUN curl -sS https://getcomposer.org/installer \

--- a/apache/crontab
+++ b/apache/crontab
@@ -1,0 +1,2 @@
+## Customize the line below to run regularly your PHP scripts.
+# * * * * * cd /var/www/html/; /usr/local/bin/php my_script.php | tee -a /var/logs/cron/my_script.log

--- a/apache/entrypoint.sh
+++ b/apache/entrypoint.sh
@@ -4,4 +4,5 @@ chgrp www-data /var/www/html;
 chgrp -R www-data /var/www/html;
 chmod g+rw -R $(ls /var/www/html | awk '{if($1 != "vendor"){ print $1 }}');
 
+cron
 exec /usr/sbin/apachectl -DFOREGROUND;

--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -20,6 +20,8 @@ services:
   php-apache-engine:
     volumes:
       - ./apache/volume:/var/www/html:rw
+      - ./apache/logs/apache2:/var/logs/apache2:rw
+      - ./apache/logs/cron:/var/logs/cron:rw
       #- ./apache/ext-xdebug.ini:/usr/local/etc/php/conf.d/ext-xdebug.ini:ro
     restart: unless-stopped
     build: ./apache


### PR DESCRIPTION
This PR adds support for CRON tasks in the Apache container.

Also, it slightly changes the docker-compose file to store logs in the apache/logs directory (useful to review logs even after the containers are stopped).